### PR TITLE
Adding log_req_limit value

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ To install the project's dependencies, clone this repo to the host machine and r
 | client_id | `OAuth` client id. Required if `auth_method` is `oauth`. | No
 | scope | `OAuth` scope. Required if `auth_method` is `oauth`. | No
 | req_limit | Default is `10000`. Limits number of records returned from the API. | No
+| log_req_limit | Default is `10000`. Limits number of log records returned from the API. | No
 | key_sizes | Default is a list of `[512, 1024, 2048]` | No
 | key_algorithms | Default is a list of `["RSA", "ECC"]` | No
 | min_collection_interval | Default is `60`. Sets the minimum interval of metrics collections when the DataDog agent is running.| No

--- a/checks.d/venafi_cert.py
+++ b/checks.d/venafi_cert.py
@@ -11,6 +11,7 @@ from datadog_checks.checks import AgentCheck
 class VenafiCheck(AgentCheck):
     UTCNOW = datetime.utcnow()
     LIMIT = 5000
+    LOG_LIMIT = 10000
 
     KEY_SIZES = [256, 512, 1024, 2048]
     KEY_ALGOS = ["RSA", "ECC"]
@@ -75,6 +76,9 @@ class VenafiCheck(AgentCheck):
 
         if "req_limit" in instance:
             self.LIMIT = instance["req_limit"]
+
+        if "log_req_limit" in instance:
+            self.LOG_LIMIT = instance["log_req_limit"]
 
         if "key_sizes" in instance:
             self.KEY_SIZES = instance["key_sizes"]
@@ -305,7 +309,7 @@ class VenafiCheck(AgentCheck):
                 tags=[
                     "key_algorithm:%s" % algo.lower(),
                     "metric_submission_type:count",
-                ],
+                    ],
             )
 
     def count_keysize_certs(self):
@@ -532,7 +536,7 @@ class VenafiCheck(AgentCheck):
         url = self.BASE_URL + "/vedsdk/Log/"
 
         params = {
-            "limit": self.LIMIT,
+            "limit": self.LOG_LIMIT,
         }
 
         headers = {

--- a/checks.d/venafi_cert.py
+++ b/checks.d/venafi_cert.py
@@ -309,7 +309,7 @@ class VenafiCheck(AgentCheck):
                 tags=[
                     "key_algorithm:%s" % algo.lower(),
                     "metric_submission_type:count",
-                    ],
+                ],
             )
 
     def count_keysize_certs(self):

--- a/conf.d/venafi_cert.yaml
+++ b/conf.d/venafi_cert.yaml
@@ -8,6 +8,7 @@ instances:
   #   client_id: "clientid"
   #   scope: "scope:scope"
   #   req_limit: 10000
+  #   log_req_limit: 10000
   #   key_sizes:
   #     - 512
   #     - 1024


### PR DESCRIPTION
Adding new log_req_limit value to venafi_cert.yaml and python file. This allows users to separate the two and specify different values for each based on their needs instead of have one value for everything.

Adding a default variable LOG_LIMIT set to 10000.
Adding if statement for passed log_req_limit value from yaml.
Changing params for POST request in get_log_events method to LOG_LIMIT variable.
Adding log_req_limit to yaml example.
Adding log_req_limit to README.

fixes #5 